### PR TITLE
Add a link to the `Try it!` section of the readme on a bad request.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn handle_request(speak: &Mutex<speak::Speak>, request: Request<Body>) -> Respon
   }
 
   let text: &str = match &text {
-    None => return bad_request("No text= query parameter"),
+    None => return bad_request("No text= query parameter\nhttps://github.com/SquidDev-CC/CCSpeaks#try-it"),
     Some(x) => x,
   };
   let voice = match &voice {


### PR DESCRIPTION
I have noticed people just posting the raw `music.madefor.cc/tts` link, and asking how to use it.
I think adding a link to the README would help a lot here.